### PR TITLE
upgrading json5 version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,14 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "checks-action",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.2.6",
         "@actions/github": "^4.0.0",
-        "@octokit/rest": "^18.0.5"
+        "@octokit/rest": "^18.0.5",
+        "json5": "^2.2.3"
       },
       "devDependencies": {
         "@types/jest": "^26.0.13",
@@ -5859,13 +5861,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -13475,13 +13473,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5"
-      }
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
     },
     "jsprim": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "dependencies": {
     "@actions/core": "^1.2.6",
     "@actions/github": "^4.0.0",
-    "@octokit/rest": "^18.0.5"
+    "@octokit/rest": "^18.0.5",
+    "json5": "^2.2.3"
   },
   "devDependencies": {
     "@types/jest": "^26.0.13",


### PR DESCRIPTION
This is a PR for this ticket here: https://drizly.atlassian.net/browse/SRE-384

Upgrading the json5 version to ">= 2.2.2" for security compliance work